### PR TITLE
Changed exit codes for found and not found unused deps

### DIFF
--- a/unused_scanner
+++ b/unused_scanner
@@ -47,12 +47,12 @@ try{
     $result = array_diff(array_unique(array_values($searchMap)), $scanResult);
     if(empty($result)){
         echo PHP_EOL.'Unused dependencies not found!'.PHP_EOL;
-    }else{
-        echo PHP_EOL.'Unused dependencies found!'.PHP_EOL;
-        print_r(array_values($result));
-        echo PHP_EOL;
+        exit(0);
     }
-    exit(0);
+    echo PHP_EOL.'Unused dependencies found!'.PHP_EOL;
+    print_r(array_values($result));
+    echo PHP_EOL;
+    exit(1);
 }catch (\Throwable $e){
     echo 'Error! '.$e->getMessage().PHP_EOL;
     echo $e->getTraceAsString().PHP_EOL;


### PR DESCRIPTION
Hello!
It's hard to use unused scanner on CI, because it does not return properly exit codes.

Default expected behaviour is following:

* `0` - when no unused deps found
* `1` - when found at least one unused dependency

So I `unused_scanner` script to follow that behaviour