### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .php_cs.cache
 tests/reports/*.txt
 tests/reports/*.json
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,9 @@ cache:
     - $HOME/.composer/cache
     - vendor
 
-before_install:
-  - sudo apt-get update -qq
-
 install:
   - phpenv config-rm xdebug.ini || echo "xdebug is not installed"
   - travis_retry composer self-update && composer --version
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - travis_retry composer install --prefer-dist --no-interaction
 
 script: vendor/bin/phpunit -vvv

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,11 @@
         }
     ] ,
     "minimum-stability": "dev" ,
+    "prefer-stable": true ,
     "require":           {
         "php":            ">=7.1" ,
         "ext-json":       "*" ,
+        "ext-mbstring": "*" ,
         "symfony/finder": "^3.4|^4.0" ,
         "nesbot/carbon":  ">=1.22"
     } ,
@@ -25,9 +27,10 @@
     ] ,
     "autoload":          {
         "psr-4": {
-            "insolita\\Scanner\\": ""
+            "insolita\\Scanner\\Lib\\": "Lib" ,
+            "insolita\\Scanner\\Exceptions\\": "Exceptions"
         }
-    },
+    } ,
     "extra": {
         "branch-alias": {
             "dev-legacy": "1.3.x-dev"

--- a/tests/ScannerTest.php
+++ b/tests/ScannerTest.php
@@ -30,7 +30,7 @@ class ScannerTest extends TestCase
             'A2I\\GeoBundle\\' => 17,
             'Bazinga\\GeocoderBundle\\' => 18,
         ];
-    
+
     public function testDetection()
     {
         $config = new Config(__DIR__ . '/../composer.json', __DIR__ . '/../vendor', [__DIR__ . '/stubs/']);
@@ -41,7 +41,7 @@ class ScannerTest extends TestCase
         sort($founds);
         $this->assertEquals([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], $founds);
     }
-    
+
     public function testScanAdditionalFiles()
     {
         $config = new Config(__DIR__ . '/../composer.json', __DIR__ . '/../vendor', []);
@@ -53,7 +53,7 @@ class ScannerTest extends TestCase
         sort($founds);
         $this->assertEquals([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], $founds);
     }
-    
+
     public function testScanWithCustomMatch()
     {
         $map = array_merge(self::$map, ['Foo\Bar' => 17, 'Bar\Baz' => 18]);
@@ -62,7 +62,7 @@ class ScannerTest extends TestCase
             if ($packageName === 18) {
                 return true;
             }
-            
+
             if ($file->getExtension() === 'twig') {
                 $definition = str_replace('\\', '/', $definition);
                 if (mb_strpos($file->getContents(), $definition) !== false) {
@@ -78,7 +78,7 @@ class ScannerTest extends TestCase
         sort($founds);
         $this->assertEquals([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18], $founds);
     }
-    
+
     public function testYmlScan()
     {
         $config = new Config(__DIR__ . '/../composer.json', __DIR__ . '/../vendor', [__DIR__ . '/stubs/']);
@@ -90,7 +90,7 @@ class ScannerTest extends TestCase
         sort($founds);
         $this->assertEquals([17], $founds);
     }
-    
+
     public function testSymfonyCustomScan()
     {
         $config = (new Config(__DIR__ . '/../composer.json', __DIR__ . '/../vendor', [__DIR__ . '/stubs/']))


### PR DESCRIPTION
# Changed log
- Removing unused command during Travis CI build.
- Since using the `PHPUnit 8+` version, it will generate the cached `.phpunit.result.cache` file automatically after running `PHPUnit` test work.
It should define this file on `.gitignore` file to avoid versioning on `Git` version control.
- Correcting the `PSR-4` autoloading on `composer.json`.
- Removing additional white spaces on some classes.
