### PR TITLE
Compile to phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 tests/reports/*.txt
 tests/reports/*.json
 .phpunit.result.cache
+unused_scanner.phar

--- a/README.md
+++ b/README.md
@@ -12,20 +12,6 @@ Use 2.x versions for projects with php >= 7.1
 
 see [CHANGELOG.md](CHANGELOG.md)
 
-### Installation
-
-`composer global require insolita/unused-scanner`
-
-Ensure that your ~/.composer/vendor/bin directory declared in $PATH
-
-`echo $PATH`
-
-if not - you should add it in ~/.bashrc or ~/.profile
-
-### Update
-
-`composer global update`
-
 ### Usage
 
 prepare configuration file, see [scanner_config.example.php](scanner_config.example.php)
@@ -34,16 +20,16 @@ put it in project root (or other place)
 
 run `composer dumpautoload` in your project directory
 
-run `unused_scanner /path/to/configuration/file/scanner_config.php`
+run `unused_scanner.phar /path/to/configuration/file/scanner_config.php`
 
-since 1.1 you can run it without  argument, if scanner_config.php existed in current working directory, it will be used
+since 1.1 you can run it without argument, if scanner_config.php existed in current working directory, it will be used
 by default
 
 **For auto-testing**:
 
 Add --silent option for skip progress output and return exit code = 16, when unused packages detected
 
-run `unused_scanner /path/to/configuration/file/scanner_config.php --silent`
+run `unused_scanner.phar /path/to/configuration/file/scanner_config.php --silent`
 
 **Docker**:
 

--- a/compile
+++ b/compile
@@ -1,0 +1,91 @@
+#!/usr/bin/env php
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Process;
+
+$pharFile = 'unused_scanner.phar';
+
+if (file_exists($pharFile)) {
+    unlink($pharFile);
+}
+
+$process = new Process([
+    'composer',
+    'install',
+    '--no-dev',
+]);
+$process->mustRun();
+
+$phar = new \Phar($pharFile, 0, 'unused_scanner.phar');
+$phar->setSignatureAlgorithm(\Phar::SHA1);
+$phar->startBuffering();
+
+$finder = new Finder();
+$finder->files()
+    ->ignoreVCS(true)
+    ->name('*.php')
+    ->in([
+        __DIR__.'/Exceptions',
+        __DIR__.'/Lib',
+    ])
+;
+foreach ($finder as $file) {
+    $phar->addFromString(relativePath($file), file_get_contents($file));
+}
+
+$finder = new Finder();
+$finder->files()
+    ->ignoreVCS(true)
+    ->name('*.php')
+    ->exclude('Tests')
+    ->exclude('tests')
+    ->exclude('docs')
+    ->in(__DIR__.'/vendor')
+;
+
+foreach ($finder as $file) {
+    $phar->addFromString(relativePath($file), file_get_contents($file));
+}
+
+$content = file_get_contents(__DIR__.'/unused_scanner');
+$content = preg_replace('{^#!/usr/bin/env php\s*}', '', $content);
+$phar->addFromString('unused_scanner', $content);
+
+$phar->setStub(stub());
+
+$phar->stopBuffering();
+
+chmod($pharFile, 0755);
+
+$process = new Process([
+    'composer',
+    'install',
+]);
+$process->mustRun();
+
+function relativePath(\SplFileInfo $file)
+{
+    $realPath = $file->getRealPath();
+    $pathPrefix = __DIR__.DIRECTORY_SEPARATOR;
+
+    $pos = strpos($realPath, $pathPrefix);
+    $relativePath = ($pos !== false) ? substr_replace($realPath, '', $pos, strlen($pathPrefix)) : $realPath;
+
+    return strtr($relativePath, '\\', '/');
+}
+
+function stub()
+{
+    $stub = <<<'EOF'
+#!/usr/bin/env php
+<?php
+Phar::mapPhar('unused_scanner.phar');
+EOF;
+
+    return $stub . <<<'EOF'
+require 'phar://unused_scanner.phar/unused_scanner';
+__HALT_COMPILER();
+EOF;
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "ext-json":       "*" ,
         "ext-mbstring":   "*" ,
         "symfony/finder": "^3.4|^4.0|^5.0" ,
+        "symfony/process": "^3.4|^4.0|^5.0",
         "nesbot/carbon":  ">=1.22"
     } ,
     "require-dev":       {


### PR DESCRIPTION
Fixes #33

`php -d phar.readonly=0 ./compile` will produce `unused_scanner.phar`

This file may be uploaded as a binary to a release (now there are a no releases only git tags)