### PR TITLE
Added `--no-progress` option

### DIFF
--- a/Lib/Runner.php
+++ b/Lib/Runner.php
@@ -31,11 +31,17 @@ final class Runner
      * @var bool
      */
     private $silentMode;
+
+    /**
+     * @var bool
+     */
+    private $noProgress;
     
-    public function __construct(string $configFile, bool $silentMode)
+    public function __construct(string $configFile, bool $silentMode, bool $noProgress)
     {
         $this->configFile = $configFile;
         $this->silentMode = $silentMode;
+        $this->noProgress = $noProgress;
     }
 
     public function run(): int
@@ -71,6 +77,10 @@ final class Runner
     
     public function onProgress(int $done, int $total): void
     {
+        if ($this->noProgress === true) {
+            return;
+        }
+
         $width = 60;
         $percentage = round(($done * 100) / ($total <= 0 ? 1 : $total));
         $bar = (int)round(($width * $percentage) / 100);

--- a/unused_scanner
+++ b/unused_scanner
@@ -24,11 +24,13 @@ if ($argc > 1 && strpos($argv[1] ?? '', '-') !== 0) {
     $configPath = $argv[1];
     $args = array_slice($argv, 1);
     $silentMode = in_array('-s', $args, true) || in_array('--silent', $args, true);
+    $noProgress = in_array('--no-progress', $args, true);
     $showVersion = in_array('--version', $args, true);
 } else {
-    $options = getopt('s', ['silent', 'version'], $optIndex);
+    $options = getopt('s', ['silent', 'version', 'no-progress'], $optIndex);
     $configPath = (int)$optIndex < $argc && $argc > 1 ? array_slice($argv, $optIndex)[0] : null;
     $silentMode = isset($options['s']) || isset($options['silent']);
+    $noProgress = isset($options['no-progress']);
     $showVersion = isset($options['version']);
 }
 
@@ -51,7 +53,6 @@ if (!file_exists($configPath)) {
     exit(Runner::ARGUMENT_ERROR_CODE);
 }
 
-$exitCode = (new Runner((string)$configPath, $silentMode))->run();
+$exitCode = (new Runner((string)$configPath, $silentMode, $noProgress))->run();
 
 exit($exitCode);
-


### PR DESCRIPTION
Adding `--no-progress` option to be able to disable progress output on CI as it produces an "ugly" output:

![image](https://github.com/Insolita/unused-scanner/assets/598744/073caee2-ef1d-4224-9342-93bf36ac9aff)
